### PR TITLE
Saves settings across game reloads

### DIFF
--- a/unity/igt-components-package/Runtime/Settings/Prefabs/Components/Small Button.prefab
+++ b/unity/igt-components-package/Runtime/Settings/Prefabs/Components/Small Button.prefab
@@ -328,3 +328,4 @@ MonoBehaviour:
   image: {fileID: 1880807335342084618}
   label: {fileID: 2433981210921986380}
   onColor: {r: 0.03137255, g: 0.7137255, b: 1, a: 1}
+  offColor: {r: 1, g: 1, b: 1, a: 1}

--- a/unity/igt-components-package/Runtime/Settings/Scripts/SettingsController.cs
+++ b/unity/igt-components-package/Runtime/Settings/Scripts/SettingsController.cs
@@ -26,16 +26,57 @@ namespace InfinityGameTable.Settings
         public ToggleButtonExtension musicButton;
 
         [HideInInspector]
-        public Settings config;
+        public Settings settingsConfig;
 
-        private bool isVibrationEnabled = true;
-        private bool isSFXEnabled = true;
-        private bool isMusicEnabled = true;
-
-        void Awake()
+        private string isVibrationEnabledKey = "isVibrationEnabled";
+        private bool isVibrationEnabled
         {
-            config = GetComponentInParent<Settings>();
-            if (!config) throw new System.Exception($"Missing Settings component on parent of {gameObject.name}");
+            get
+            {
+                return PlayerPrefs.GetInt(isVibrationEnabledKey, 1) == 1;
+            }
+
+            set
+            {
+                PlayerPrefs.SetInt(isVibrationEnabledKey, value ? 1 : 0);
+                PlayerPrefs.Save();
+            }
+        }
+
+        private string isSFXEnabledKey = "isSFXEnabled";
+        private bool isSFXEnabled
+        {
+            get
+            {
+                return PlayerPrefs.GetInt(isSFXEnabledKey, 1) == 1;
+            }
+
+            set
+            {
+                PlayerPrefs.SetInt(isSFXEnabledKey, value ? 1 : 0);
+                PlayerPrefs.Save();
+            }
+        }
+
+        private string isMusicEnabledKey = "isMusicEnabled";
+        private bool isMusicEnabled
+        {
+            get
+            {
+                return PlayerPrefs.GetInt(isMusicEnabledKey, 1) == 1;
+            }
+
+            set
+            {
+                PlayerPrefs.SetInt(isMusicEnabledKey, value ? 1 : 0);
+                PlayerPrefs.Save();
+            }
+        }
+
+        void Start()
+        {
+            settingsConfig = GetComponentInParent<Settings>();
+            if (!settingsConfig) throw new System.Exception($"Missing Settings component on parent of {gameObject.name}");
 
             if (!settingsButton) throw new System.Exception($"Missing Settings Button for {gameObject.name}");
             if (!settingsPanel) throw new System.Exception($"Missing Settings Panel game object for {gameObject.name}");
@@ -47,7 +88,12 @@ namespace InfinityGameTable.Settings
             settingsPanel.SetActive(false);
             howToPlayPanel.SetActive(false);
 
-            versionLabel.text = $"V{Application.version}";
+            versionLabel.text = $"v{Application.version}";
+
+            // Load values from PlayerPrefs
+            SetVibration(isVibrationEnabled);
+            SetSFX(isSFXEnabled);
+            SetMusic(isMusicEnabled);
         }
 
         public void ToggleSettingsPanelActive()
@@ -68,17 +114,17 @@ namespace InfinityGameTable.Settings
 
             if (settingsPanel.activeInHierarchy)
             {
-                config.onShowSettingsMenu.Invoke();
+                settingsConfig.onShowSettingsMenu.Invoke();
             }
             else
             {
-                config.onHideSettingsMenu.Invoke();
+                settingsConfig.onHideSettingsMenu.Invoke();
             }
         }
 
         public void GoHome()
         {
-            config.onGoHome.Invoke();
+            settingsConfig.onGoHome.Invoke();
             SetSettingsPanelActive(false);
         }
 
@@ -94,17 +140,8 @@ namespace InfinityGameTable.Settings
 
         public void ToggleVibration()
         {
-            config.onToggleVibration.Invoke();
-            isVibrationEnabled = !isVibrationEnabled;
-            if (isVibrationEnabled)
-            {
-                config.onEnableVibration.Invoke();
-            }
-            else
-            {
-                config.onDisableVibration.Invoke();
-            }
-            vibrationButton.SetOn(isVibrationEnabled);
+            settingsConfig.onToggleVibration.Invoke();
+            SetVibration(!isVibrationEnabled);
 
             if (isVibrationEnabled)
             {
@@ -114,32 +151,56 @@ namespace InfinityGameTable.Settings
 
         public void ToggleSFX()
         {
-            config.onToggleSFX.Invoke();
-            isSFXEnabled = !isSFXEnabled;
-            if (isSFXEnabled)
-            {
-                config.onEnableSFX.Invoke();
-            }
-            else
-            {
-                config.onDisableSFX.Invoke();
-            }
-            sfxButton.SetOn(isSFXEnabled);
+            settingsConfig.onToggleSFX.Invoke();
+            SetSFX(!isSFXEnabled);
         }
 
         public void ToggleMusic()
         {
-            config.onToggleMusic.Invoke();
-            isMusicEnabled = !isMusicEnabled;
-            if (isMusicEnabled)
+            settingsConfig.onToggleMusic.Invoke();
+            SetMusic(!isMusicEnabled);
+        }
+
+        private void SetVibration(bool isEnabled)
+        {
+            isVibrationEnabled = isEnabled;
+            if (isEnabled)
             {
-                config.onEnableMusic.Invoke();
+                settingsConfig.onEnableVibration.Invoke();
             }
             else
             {
-                config.onDisableMusic.Invoke();
+                settingsConfig.onDisableVibration.Invoke();
             }
-            musicButton.SetOn(isMusicEnabled);
+            vibrationButton.SetOn(isEnabled);
+        }
+
+        private void SetSFX(bool isEnabled)
+        {
+            isSFXEnabled = isEnabled;
+            if (isEnabled)
+            {
+                settingsConfig.onEnableSFX.Invoke();
+            }
+            else
+            {
+                settingsConfig.onDisableSFX.Invoke();
+            }
+            sfxButton.SetOn(isEnabled);
+        }
+
+        private void SetMusic(bool isEnabled)
+        {
+            isMusicEnabled = isEnabled;
+            if (isEnabled)
+            {
+                settingsConfig.onEnableMusic.Invoke();
+            }
+            else
+            {
+                settingsConfig.onDisableMusic.Invoke();
+            }
+            musicButton.SetOn(isEnabled);
         }
     }
 }

--- a/unity/igt-components-package/Runtime/Settings/Scripts/ToggleButtonExtension.cs
+++ b/unity/igt-components-package/Runtime/Settings/Scripts/ToggleButtonExtension.cs
@@ -8,8 +8,8 @@ namespace InfinityGameTable.Settings
         public Image image;
         public Text label;
         public Color onColor;
+        public Color offColor;
         
-        private Color offColor;
         private bool isOn = true;
 
         private void Awake()
@@ -17,7 +17,6 @@ namespace InfinityGameTable.Settings
             if (!image) throw new System.Exception($"Missing Image for {gameObject.name}");
             if (!label) throw new System.Exception($"Missing Label for {gameObject.name}");
 
-            offColor = image.color;
             UpdateDisplay();
         }
 

--- a/unity/igt-components-package/Runtime/Settings/Settings.prefab
+++ b/unity/igt-components-package/Runtime/Settings/Settings.prefab
@@ -868,7 +868,7 @@ MonoBehaviour:
   vibrationButton: {fileID: 2940191228375878148}
   sfxButton: {fileID: 4398729202276740813}
   musicButton: {fileID: 234904013482508734}
-  config: {fileID: 0}
+  settingsConfig: {fileID: 0}
 --- !u!1 &6035674466524824428
 GameObject:
   m_ObjectHideFlags: 0
@@ -2848,3 +2848,4 @@ MonoBehaviour:
   image: {fileID: 8100826418657198689}
   label: {fileID: 5455319268777326887}
   onColor: {r: 0.03137255, g: 0.7137255, b: 1, a: 1}
+  offColor: {r: 1, g: 1, b: 1, a: 1}


### PR DESCRIPTION
* Settings for vibration, sfx, and music are now saved to PlayerPrefs, which are stored in local files and preserved across game reloads
* Automatically loads previously saved state of buttons on scene load
* Added explicit setting of "offColor" for toggle buttons to fix issue where they start in the "off" state